### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/src/integrationtest/python/integrationtest_support.py
+++ b/src/integrationtest/python/integrationtest_support.py
@@ -57,17 +57,17 @@ class IntegrationTestSupport(unittest.TestCase):
 
     def assert_directory_exists(self, name):
         full_path = self.full_path(name)
-        self.assertTrue(os.path.exists(full_path), msg="Directory does not exist: %s" % full_path)
-        self.assertTrue(os.path.isdir(full_path), msg="Not a directory: %s" % full_path)
+        self.assertTrue(os.path.exists(full_path), msg="Directory does not exist: {0!s}".format(full_path))
+        self.assertTrue(os.path.isdir(full_path), msg="Not a directory: {0!s}".format(full_path))
 
     def assert_file_does_not_exist(self, name):
         full_path = self.full_path(name)
-        self.assertFalse(os.path.exists(full_path), msg="File should NOT exist: %s" % full_path)
+        self.assertFalse(os.path.exists(full_path), msg="File should NOT exist: {0!s}".format(full_path))
 
     def assert_file_exists(self, name):
         full_path = self.full_path(name)
-        self.assertTrue(os.path.exists(full_path), msg="File does not exist: %s" % full_path)
-        self.assertTrue(os.path.isfile(full_path), msg="Not a file: %s" % full_path)
+        self.assertTrue(os.path.exists(full_path), msg="File does not exist: {0!s}".format(full_path))
+        self.assertTrue(os.path.isfile(full_path), msg="Not a file: {0!s}".format(full_path))
 
     def assert_file_permissions(self, expected_permissions, name):
         full_path = self.full_path(name)
@@ -77,7 +77,7 @@ class IntegrationTestSupport(unittest.TestCase):
     def assert_file_empty(self, name):
         self.assert_file_exists(name)
         full_path = self.full_path(name)
-        self.assertEquals(0, os.path.getsize(full_path), msg="File %s is not empty." % full_path)
+        self.assertEquals(0, os.path.getsize(full_path), msg="File {0!s} is not empty.".format(full_path))
 
     def assert_file_contains(self, name, expected_content_part):
         full_path = self.full_path(name)

--- a/src/main/python/pybuilder/cli.py
+++ b/src/main/python/pybuilder/cli.py
@@ -188,14 +188,14 @@ def parse_options(args):
     options, arguments = parser.parse_args(args=list(args))
 
     if options.list_tasks and options.list_plan_tasks:
-        parser.error("%s and %s are mutually exclusive" % (list_tasks_option, list_plan_tasks_option))
+        parser.error("{0!s} and {1!s} are mutually exclusive".format(list_tasks_option, list_plan_tasks_option))
     if options.start_project and options.update_project:
-        parser.error("%s and %s are mutually exclusive" % (start_project_option, update_project_option))
+        parser.error("{0!s} and {1!s} are mutually exclusive".format(start_project_option, update_project_option))
 
     property_overrides = {}
     for pair in options.property_overrides:
         if not PROPERTY_OVERRIDE_PATTERN.match(pair):
-            parser.error("%s is not a property definition." % pair)
+            parser.error("{0!s} is not a property definition.".format(pair))
         key, val = pair.split("=")
         property_overrides[key] = val
 
@@ -234,17 +234,16 @@ def init_logger(options):
 
 def print_build_summary(options, summary):
     print_text_line("Build Summary")
-    print_text_line("%20s: %s" % ("Project", summary.project.name))
-    print_text_line("%20s: %s%s" % ("Version", summary.project.version, get_dist_version_string(summary.project)))
-    print_text_line("%20s: %s" % ("Base directory", summary.project.basedir))
-    print_text_line("%20s: %s" %
-                    ("Environments", ", ".join(options.environments)))
+    print_text_line("{0:20!s}: {1!s}".format("Project", summary.project.name))
+    print_text_line("{0:20!s}: {1!s}{2!s}".format("Version", summary.project.version, get_dist_version_string(summary.project)))
+    print_text_line("{0:20!s}: {1!s}".format("Base directory", summary.project.basedir))
+    print_text_line("{0:20!s}: {1!s}".format("Environments", ", ".join(options.environments)))
 
     task_summary = ""
     for task in summary.task_summaries:
-        task_summary += " %s [%d ms]" % (task.task, task.execution_time)
+        task_summary += " {0!s} [{1:d} ms]".format(task.task, task.execution_time)
 
-    print_text_line("%20s:%s" % ("Tasks", task_summary))
+    print_text_line("{0:20!s}:{1!s}".format("Tasks", task_summary))
 
 
 def print_styled_text(text, options, *style_attributes):
@@ -270,9 +269,8 @@ def print_build_status(failure_message, options, successful):
 def print_elapsed_time_summary(start, end):
     time_needed = end - start
     millis = ((time_needed.days * 24 * 60 * 60) + time_needed.seconds) * 1000 + time_needed.microseconds / 1000
-    print_text_line("Build finished at %s" % format_timestamp(end))
-    print_text_line("Build took %d seconds (%d ms)" %
-                    (time_needed.seconds, millis))
+    print_text_line("Build finished at {0!s}".format(format_timestamp(end)))
+    print_text_line("Build took {0:d} seconds ({1:d} ms)".format(time_needed.seconds, millis))
 
 
 def print_summary(successful, summary, start, end, options, failure_message):
@@ -317,8 +315,8 @@ def print_task_list(tasks, quiet=False):
 
         if task.dependencies:
             whitespace = (column_length + 3) * " "
-            depends_on_message = "depends on tasks: %s" % " ".join(
-                [str(dependency) for dependency in task.dependencies])
+            depends_on_message = "depends on tasks: {0!s}".format(" ".join(
+                [str(dependency) for dependency in task.dependencies]))
             print_text_line(whitespace + depends_on_message)
 
 
@@ -326,14 +324,14 @@ def print_list_of_tasks(reactor, quiet=False):
     tasks = reactor.get_tasks()
     sorted_tasks = sorted(tasks)
     if not quiet:
-        print_text_line('Tasks found for project "%s":' % reactor.project.name)
+        print_text_line('Tasks found for project "{0!s}":'.format(reactor.project.name))
     print_task_list(sorted_tasks, quiet)
 
 
 def print_plan_list_of_tasks(options, arguments, reactor, quiet=False):
     execution_plan = reactor.create_execution_plan(arguments, options.environments)
     if not quiet:
-        print_text_line('Tasks that will be executed for project "%s":' % reactor.project.name)
+        print_text_line('Tasks that will be executed for project "{0!s}":'.format(reactor.project.name))
     print_task_list(execution_plan, quiet)
 
 
@@ -343,7 +341,7 @@ def main(*args):
     try:
         options, arguments = parse_options(args)
     except CommandLineUsageException as e:
-        print_error_line("Usage error: %s\n" % e)
+        print_error_line("Usage error: {0!s}\n".format(e))
         print_error(e.usage)
         return 1
 
@@ -379,7 +377,7 @@ def main(*args):
     if not options.very_quiet:
         print_styled_text_line(
             "PyBuilder version {0}".format(__version__), options, BOLD)
-        print_text_line("Build started at %s" % format_timestamp(start))
+        print_text_line("Build started at {0!s}".format(format_timestamp(start)))
         draw_line()
 
     successful = True

--- a/src/main/python/pybuilder/core.py
+++ b/src/main/python/pybuilder/core.py
@@ -320,7 +320,7 @@ class Project(object):
         self._postinstall_script = None
 
     def __str__(self):
-        return "[Project name=%s basedir=%s]" % (self.name, self.basedir)
+        return "[Project name={0!s} basedir={1!s}]".format(self.name, self.basedir)
 
     @property
     def version(self):
@@ -354,7 +354,7 @@ class Project(object):
         for dependency in self.build_dependencies:
             if dependency.name in build_dependencies_found:
                 if build_dependencies_found[dependency.name] == 1:
-                    result.append("Build dependency '%s' has been defined multiple times." % dependency.name)
+                    result.append("Build dependency '{0!s}' has been defined multiple times.".format(dependency.name))
                 build_dependencies_found[dependency.name] += 1
             else:
                 build_dependencies_found[dependency.name] = 1
@@ -364,12 +364,12 @@ class Project(object):
         for dependency in self.dependencies:
             if dependency.name in runtime_dependencies_found:
                 if runtime_dependencies_found[dependency.name] == 1:
-                    result.append("Runtime dependency '%s' has been defined multiple times." % dependency.name)
+                    result.append("Runtime dependency '{0!s}' has been defined multiple times.".format(dependency.name))
                 runtime_dependencies_found[dependency.name] += 1
             else:
                 runtime_dependencies_found[dependency.name] = 1
             if dependency.name in build_dependencies_found:
-                result.append("Runtime dependency '%s' has also been given as build dependency." % dependency.name)
+                result.append("Runtime dependency '{0!s}' has also been given as build dependency.".format(dependency.name))
 
         return result
 

--- a/src/main/python/pybuilder/execution.py
+++ b/src/main/python/pybuilder/execution.py
@@ -83,7 +83,7 @@ class Executable(object):
         if isinstance(self.callable, types.FunctionType):
             self.parameters = getargspec(self.callable).args
         else:
-            raise TypeError("Don't know how to handle callable %s" % callable)
+            raise TypeError("Don't know how to handle callable {0!s}".format(callable))
 
     @property
     def name(self):
@@ -93,7 +93,7 @@ class Executable(object):
         arguments = []
         for parameter in self.parameters:
             if parameter not in argument_dict:
-                raise ValueError("Invalid parameter '%s' for %s %s" % (parameter, self.__class__.__name__, self.name))
+                raise ValueError("Invalid parameter '{0!s}' for {1!s} {2!s}".format(parameter, self.__class__.__name__, self.name))
             arguments.append(argument_dict[parameter])
 
         self.callable(*arguments)

--- a/src/main/python/pybuilder/pip_utils.py
+++ b/src/main/python/pybuilder/pip_utils.py
@@ -52,7 +52,7 @@ def build_dependency_version_string(mixed):
         return ""
 
     try:
-        return ">=%s" % Version(version)
+        return ">={0!s}".format(Version(version))
     except InvalidVersion:
         try:
             return str(SpecifierSet(version))

--- a/src/main/python/pybuilder/pluginloader.py
+++ b/src/main/python/pybuilder/pluginloader.py
@@ -59,7 +59,7 @@ class BuiltinPluginLoader(PluginLoader):
 
     def load_plugin(self, project, name, version=None, plugin_module_name=None):
         self.logger.debug("Trying to load builtin plugin '%s'", name)
-        builtin_plugin_name = plugin_module_name or "pybuilder.plugins.%s_plugin" % name
+        builtin_plugin_name = plugin_module_name or "pybuilder.plugins.{0!s}_plugin".format(name)
 
         plugin_module = _load_plugin(builtin_plugin_name, name)
         self.logger.debug("Found builtin plugin '%s'", builtin_plugin_name)
@@ -190,8 +190,8 @@ def _install_external_plugin(project, name, version, logger, plugin_module_name,
 
 
 def _plugin_display_name(name, version, plugin_module_name):
-    return "%s%s%s" % (name, " version %s" % version if version else "",
-                       ", module name '%s'" % plugin_module_name if plugin_module_name else "")
+    return "{0!s}{1!s}{2!s}".format(name, " version {0!s}".format(version) if version else "",
+                       ", module name '{0!s}'".format(plugin_module_name) if plugin_module_name else "")
 
 
 def _load_plugin(plugin_module_name, plugin_name):

--- a/src/main/python/pybuilder/plugins/core_plugin.py
+++ b/src/main/python/pybuilder/plugins/core_plugin.py
@@ -59,12 +59,12 @@ def prepare(project, logger):
 
     plugin_dependency_versions = get_package_version(project.plugin_dependencies, logger)
     for plugin_dependency in project.plugin_dependencies:
-        logger.debug("Processing plugin dependency %s" % plugin_dependency)
+        logger.debug("Processing plugin dependency {0!s}".format(plugin_dependency))
         if plugin_dependency.name.lower() not in plugin_dependency_versions or not \
             version_satisfies_spec(plugin_dependency.version,
                                    plugin_dependency_versions[plugin_dependency.name.lower()]):
-            logger.info("Installing plugin dependency %s" % plugin_dependency)
-            log_file = project.expand_path("$dir_reports", "dependency_%s_install.log" % plugin_dependency)
+            logger.info("Installing plugin dependency {0!s}".format(plugin_dependency))
+            log_file = project.expand_path("$dir_reports", "dependency_{0!s}_install.log".format(plugin_dependency))
             pip_install(as_pip_install_target(plugin_dependency),
                         index_url=project.get_property("install_dependencies_index_url"),
                         extra_index_url=project.get_property("install_dependencies_extra_index_url"),

--- a/src/main/python/pybuilder/plugins/exec_plugin.py
+++ b/src/main/python/pybuilder/plugins/exec_plugin.py
@@ -51,8 +51,8 @@ def publish(project, logger):
 
 
 def _write_command_report(project, stdout, stderr, command_line, phase, process_return_code):
-        project.write_report('exec_%s' % phase, stdout)
-        project.write_report('exec_%s.err' % phase, stderr)
+        project.write_report('exec_{0!s}'.format(phase), stdout)
+        project.write_report('exec_{0!s}.err'.format(phase), stderr)
 
 
 def _log_quoted_output(logger, output_type, output, phase):
@@ -64,7 +64,7 @@ def _log_quoted_output(logger, output_type, output, phase):
 
 
 def run_command(phase, project, logger):
-    command_line = project.get_property('%s_command' % phase)
+    command_line = project.get_property('{0!s}_command'.format(phase))
 
     if not command_line:
         return
@@ -81,10 +81,10 @@ def run_command(phase, project, logger):
                           phase,
                           process_return_code)
 
-    if project.get_property('%s_propagate_stdout' % phase) and stdout:
+    if project.get_property('{0!s}_propagate_stdout'.format(phase)) and stdout:
         _log_quoted_output(logger, '', stdout, phase)
 
-    if project.get_property('%s_propagate_stderr' % phase) and stderr:
+    if project.get_property('{0!s}_propagate_stderr'.format(phase)) and stderr:
         _log_quoted_output(logger, 'error', stderr, phase)
 
     if process_return_code != 0:

--- a/src/main/python/pybuilder/plugins/filter_resources_plugin.py
+++ b/src/main/python/pybuilder/plugins/filter_resources_plugin.py
@@ -59,7 +59,7 @@ class ProjectDictWrapper(object):
         self.logger = logger
 
     def __getitem__(self, key):
-        fallback_when_no_substitution_possible = "${%s}" % key
+        fallback_when_no_substitution_possible = "${{{0!s}}}".format(key)
         if hasattr(self.project, key):
             return getattr(self.project, key)
         if self.project.has_property(key):

--- a/src/main/python/pybuilder/plugins/python/coverage_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/coverage_plugin.py
@@ -55,18 +55,18 @@ def verify_coverage(project, logger, reactor):
 def run_coverage(project, logger, reactor, execution_prefix, execution_name, target_task, shortest_plan=False):
     logger.info("Collecting coverage information")
 
-    if project.get_property("%s_fork" % execution_prefix) is not None:
+    if project.get_property("{0!s}_fork".format(execution_prefix)) is not None:
         logger.warn(
             "%s_fork is deprecated, coverage always runs in its own fork", execution_prefix)
 
-    if project.get_property("%s_reload_modules" % execution_prefix) is not None:
+    if project.get_property("{0!s}_reload_modules".format(execution_prefix)) is not None:
         logger.warn(
             "%s_reload_modules is deprecated - modules are no longer reloaded", execution_prefix)
 
-    if project.get_property("%s_branch_threshold_warn" % execution_prefix) == 0:
+    if project.get_property("{0!s}_branch_threshold_warn".format(execution_prefix)) == 0:
         logger.warn("%s_branch_threshold_warn is 0 and branch coverage will not be checked", execution_prefix)
 
-    if project.get_property("%s_branch_partial_threshold_warn" % execution_prefix) == 0:
+    if project.get_property("{0!s}_branch_partial_threshold_warn".format(execution_prefix)) == 0:
         logger.warn("%s_branch_partial_threshold_warn is 0 and partial branch coverage will not be checked",
                     execution_prefix)
 
@@ -76,9 +76,9 @@ def run_coverage(project, logger, reactor, execution_prefix, execution_name, tar
                                 args=(
                                     project, logger, reactor, execution_prefix, execution_name,
                                     target_task, shortest_plan))
-    if exit_code and project.get_property("%s_break_build" % execution_prefix):
+    if exit_code and project.get_property("{0!s}_break_build".format(execution_prefix)):
         raise BuildFailedException(
-            "Forked %s process indicated failure with error code %d" % (execution_name, exit_code))
+            "Forked {0!s} process indicated failure with error code {1:d}".format(execution_name, exit_code))
 
 
 def do_coverage(project, logger, reactor, execution_prefix, execution_name, target_task, shortest_plan):
@@ -88,7 +88,7 @@ def do_coverage(project, logger, reactor, execution_prefix, execution_name, targ
     It's best to simple let this method exit and the fork die rather than to try to recover.
     """
     source_tree_path = project.get_property("dir_source_main_python")
-    reset_modules = project.get_property("%s_reset_modules" % execution_prefix)
+    reset_modules = project.get_property("{0!s}_reset_modules".format(execution_prefix))
     module_names = _discover_modules_to_cover(project)
 
     for module_name in module_names:
@@ -113,7 +113,7 @@ def do_coverage(project, logger, reactor, execution_prefix, execution_name, targ
     finally:
         _stop_coverage(project, coverage)
 
-    module_exceptions = project.get_property("%s_exceptions" % execution_prefix)
+    module_exceptions = project.get_property("{0!s}_exceptions".format(execution_prefix))
     modules = _list_all_covered_modules(logger, module_names, module_exceptions)
 
     failure = _build_coverage_report(project, logger, execution_name, execution_prefix, coverage, modules)
@@ -163,9 +163,9 @@ def _build_coverage_report(project, logger, execution_name, execution_prefix, co
     coverage_too_low = False
     branch_coverage_too_low = False
     branch_partial_coverage_too_low = False
-    threshold = project.get_property("%s_threshold_warn" % execution_prefix)
-    branch_threshold = project.get_property("%s_branch_threshold_warn" % execution_prefix)
-    branch_partial_threshold = project.get_property("%s_branch_partial_threshold_warn" % execution_prefix)
+    threshold = project.get_property("{0!s}_threshold_warn".format(execution_prefix))
+    branch_threshold = project.get_property("{0!s}_branch_threshold_warn".format(execution_prefix))
+    branch_partial_threshold = project.get_property("{0!s}_branch_partial_threshold_warn".format(execution_prefix))
 
     report = {
         "module_names": []
@@ -203,17 +203,17 @@ def _build_coverage_report(project, logger, execution_name, execution_prefix, co
         logger.debug("Module coverage report: %s", module_report)
         report["module_names"].append(module_report)
         if module_report_data.code_coverage < threshold:
-            msg = "Test coverage below %2d%% for %s: %2d%%" % (threshold, module_name, module_report_data.code_coverage)
+            msg = "Test coverage below {0:2d}% for {1!s}: {2:2d}%".format(threshold, module_name, module_report_data.code_coverage)
             logger.warn(msg)
             coverage_too_low = True
         if module_report_data.branch_coverage < branch_threshold:
-            msg = "Branch coverage below %2d%% for %s: %2d%%" % (
+            msg = "Branch coverage below {0:2d}% for {1!s}: {2:2d}%".format(
                 branch_threshold, module_name, module_report_data.branch_coverage)
             logger.warn(msg)
             branch_coverage_too_low = True
 
         if module_report_data.branch_partial_coverage < branch_partial_threshold:
-            msg = "Partial branch coverage below %2d%% for %s: %2d%%" % (
+            msg = "Partial branch coverage below {0:2d}% for {1!s}: {2:2d}%".format(
                 branch_partial_threshold, module_name, module_report_data.branch_partial_coverage)
             logger.warn(msg)
             branch_partial_coverage_too_low = True
@@ -254,15 +254,15 @@ def _build_coverage_report(project, logger, execution_name, execution_prefix, co
     else:
         logger.info("Overall %s partial branch coverage is %2d%%", execution_name, overall_branch_partial_coverage)
 
-    project.write_report("%s.json" % execution_prefix, render_report(report))
+    project.write_report("{0!s}.json".format(execution_prefix), render_report(report))
 
     _write_summary_report(coverage, project, modules, execution_prefix, execution_name)
 
-    if coverage_too_low and project.get_property("%s_break_build" % execution_prefix):
+    if coverage_too_low and project.get_property("{0!s}_break_build".format(execution_prefix)):
         return BuildFailedException("Test coverage for at least one module is below %d%%", threshold)
-    if branch_coverage_too_low and project.get_property("%s_break_build" % execution_prefix):
+    if branch_coverage_too_low and project.get_property("{0!s}_break_build".format(execution_prefix)):
         return BuildFailedException("Test branch coverage for at least one module is below %d%%", branch_threshold)
-    if branch_partial_coverage_too_low and project.get_property("%s_break_build" % execution_prefix):
+    if branch_partial_coverage_too_low and project.get_property("{0!s}_break_build".format(execution_prefix)):
         return BuildFailedException("Test partial branch coverage for at least one module is below %d%%",
                                     branch_partial_threshold)
 
@@ -274,8 +274,8 @@ def _write_summary_report(coverage, project, modules, execution_prefix, executio
     try:
         coverage.report(modules, file=summary)
         try:
-            coverage.xml_report(modules, outfile=project.expand_path("$dir_reports/%s.xml" % execution_prefix))
-            coverage.html_report(modules, directory=project.expand_path("$dir_reports/%s_html" % execution_prefix),
+            coverage.xml_report(modules, outfile=project.expand_path("$dir_reports/{0!s}.xml".format(execution_prefix)))
+            coverage.html_report(modules, directory=project.expand_path("$dir_reports/{0!s}_html".format(execution_prefix)),
                                  title=execution_name)
             coverage.save()
         except CoverageException:

--- a/src/main/python/pybuilder/plugins/python/distutils_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/distutils_plugin.py
@@ -164,8 +164,8 @@ def write_manifest_file(project, logger):
         logger.debug("No data to write into MANIFEST.in")
         return
 
-    logger.debug("Files included in MANIFEST.in: %s" %
-                 project.manifest_included_files)
+    logger.debug("Files included in MANIFEST.in: {0!s}".format(
+                 project.manifest_included_files))
 
     manifest_filename = project.expand_path("$dir_dist", "MANIFEST.in")
     logger.info("Writing MANIFEST.in as %s", manifest_filename)
@@ -180,11 +180,11 @@ def render_manifest_file(project):
     manifest_content = StringIO()
 
     for included_file in project.manifest_included_files:
-        manifest_content.write("include %s\n" % included_file)
+        manifest_content.write("include {0!s}\n".format(included_file))
 
     for directory, pattern_list in project.manifest_included_directories:
         patterns = ' '.join(pattern_list)
-        manifest_content.write("recursive-include %s %s\n" % (directory, patterns))
+        manifest_content.write("recursive-include {0!s} {1!s}\n".format(directory, patterns))
 
     return manifest_content.getvalue()
 
@@ -205,7 +205,7 @@ def install_distribution(project, logger):
 
     _prepare_reports_dir(project)
     outfile_name = project.expand_path("$dir_reports", "distutils",
-                                       "pip_install_%s" % datetime.utcnow().strftime("%Y%m%d%H%M%S"))
+                                       "pip_install_{0!s}".format(datetime.utcnow().strftime("%Y%m%d%H%M%S")))
     pip_install(project.expand_path("$dir_dist"), index_url=project.get_property("install_dependencies_index_url"),
                 extra_index_url=project.get_property("install_dependencies_extra_index_url"),
                 force_reinstall=True, logger=logger, verbose=project.get_property("verbose"), cwd=".",
@@ -228,9 +228,9 @@ def upload(project, logger):
             upload_sign_args += ["--identity", sign_identity]
 
     logger.info("Uploading project %s-%s%s%s%s", project.name, project.version,
-                (" to repository '%s'" % repository) if repository else "",
+                (" to repository '{0!s}'".format(repository)) if repository else "",
                 get_dist_version_string(project, " as version %s"),
-                (" signing%s" % (" with %s" % sign_identity if sign_identity else "")) if upload_sign else "")
+                (" signing{0!s}".format((" with {0!s}".format(sign_identity) if sign_identity else ""))) if upload_sign else "")
     upload_cmd_line = [build_command_with_options(cmd, project.get_property("distutils_command_options")) + ["upload"] +
                        repository_args + upload_sign_args
                        for cmd in as_list(project.get_property("distutils_commands"))]
@@ -271,7 +271,7 @@ def execute_distutils(project, logger, distutils_commands, clean=False):
             return_code = _run_process_and_wait(commands, project.expand_path("$dir_dist"), output_file)
             if return_code != 0:
                 raise BuildFailedException(
-                    "Error while executing setup command %s, see %s for details" % (command, output_file_path))
+                    "Error while executing setup command {0!s}, see {1!s} for details".format(command, output_file_path))
 
 
 def strip_comments(requirements):
@@ -280,7 +280,7 @@ def strip_comments(requirements):
 
 
 def quote(requirements):
-    return ['"%s"' % requirement for requirement in requirements]
+    return ['"{0!s}"'.format(requirement) for requirement in requirements]
 
 
 def is_editable_requirement(requirement):
@@ -295,7 +295,7 @@ def flatten_and_quote(requirements_file):
 
 
 def format_single_dependency(dependency):
-    return '%s%s' % (dependency.name, build_dependency_version_string(dependency))
+    return '{0!s}{1!s}'.format(dependency.name, build_dependency_version_string(dependency))
 
 
 def build_install_dependencies_string(project):
@@ -341,7 +341,7 @@ def build_dependency_links_string(project):
         return "[]"
 
     def format_single_dependency(dependency):
-        return '%s' % dependency.url
+        return '{0!s}'.format(dependency.url)
 
     all_dependency_links = [link for link in map(format_single_dependency, dependency_links)]
     all_dependency_links.extend(editable_links_from_requirements)
@@ -377,7 +377,7 @@ def build_data_files_string(project):
     result = "[\n"
 
     for dataType, dataFiles in data_files:
-        result += (" " * (indent + 4)) + "('%s', ['" % dataType
+        result += (" " * (indent + 4)) + "('{0!s}', ['".format(dataType)
         result += "', '".join(dataFiles)
         result += "']),\n"
 
@@ -399,7 +399,7 @@ def build_package_data_string(project):
 
     for pkgType in sorted_keys:
         result += " " * (indent + 4)
-        result += "'%s': " % pkgType
+        result += "'{0!s}': ".format(pkgType)
         result += "['"
         result += "', '".join(package_data[pkgType])
         result += "'],\n"
@@ -438,7 +438,7 @@ def build_entry_points_string(project):
 
     for k in sorted(entry_points.keys()):
         result += " " * (indent + 4)
-        result += "'%s': %s" % (k, build_string_from_array(entry_points[k], indent + 8)) + ",\n"
+        result += "'{0!s}': {1!s}".format(k, build_string_from_array(entry_points[k], indent + 8)) + ",\n"
 
     result = result[:-2] + "\n"
     result += (" " * indent) + "}"
@@ -462,7 +462,7 @@ def build_string_from_array(arr, indent=12):
             if is_notstr_iterable(arr[0]):
                 result += "[" + build_string_from_array(arr[0], indent + 4) + "]"
             else:
-                result += "['%s']" % arr[0]
+                result += "['{0!s}']".format(arr[0])
         else:
             result = '[[]]'
     elif len(arr) > 1:
@@ -488,7 +488,7 @@ def build_string_from_dict(d, indent=12):
     map_elements = []
 
     for k, v in d.items():
-        map_elements.append("'%s': '%s'" % (k, v))
+        map_elements.append("'{0!s}': '{1!s}'".format(k, v))
 
     result = ""
 

--- a/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/install_dependencies_plugin.py
@@ -93,7 +93,7 @@ def create_install_log_directory(logger, project):
 def install_dependency(logger, project, dependency):
     url = getattr(dependency, "url", None)
     logger.info("Installing dependency '%s'%s", dependency.name,
-                " from %s" % url if url else "")
+                " from {0!s}".format(url) if url else "")
     log_file = project.expand_path("$dir_install_logs", dependency.name)
     log_file = re.sub(r'<|>|=', '_', log_file)
 

--- a/src/main/python/pybuilder/plugins/python/integrationtest_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/integrationtest_plugin.py
@@ -111,7 +111,7 @@ def run_integration_tests_in_parallel(project, logger):
             except Empty:
                 break
             except Exception as e:
-                logger.error("Failed to run test %r : %s" % (test, str(e)))
+                logger.error("Failed to run test {0!r} : {1!s}".format(test, str(e)))
                 failed_report = {
                     "test": test,
                     "test_file": test,
@@ -170,8 +170,8 @@ def add_additional_environment_keys(env, project):
     additional_environment = project.get_property(
         "integrationtest_additional_environment", {})
     if not isinstance(additional_environment, dict):
-        raise ValueError("Additional environment %r is not a map." %
-                         additional_environment)
+        raise ValueError("Additional environment {0!r} is not a map.".format(
+                         additional_environment))
     for key in additional_environment:
         env[key] = additional_environment[key]
 
@@ -317,14 +317,14 @@ class TaskPoolProgress(object):
             self.WAITING_SYMBOL * waiting_tasks_count, fg(GREY))
         trailing_space = ' ' if not pacman else ''
 
-        return "[%s%s%s%s]%s" % (finished_tests_progress, pacman, running_tests_progress, waiting_tasks_progress, trailing_space)
+        return "[{0!s}{1!s}{2!s}{3!s}]{4!s}".format(finished_tests_progress, pacman, running_tests_progress, waiting_tasks_progress, trailing_space)
 
     def render_to_terminal(self):
         if self.can_be_displayed:
             text_to_render = self.render()
             characters_to_be_erased = self.last_render_length
             self.last_render_length = len(text_to_render)
-            text_to_render = "%s%s" % (characters_to_be_erased * self.BACKSPACE, text_to_render)
+            text_to_render = "{0!s}{1!s}".format(characters_to_be_erased * self.BACKSPACE, text_to_render)
             print_text(text_to_render, flush=True)
 
     def mark_as_finished(self):

--- a/src/main/python/pybuilder/plugins/python/pychecker_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/pychecker_plugin.py
@@ -62,7 +62,7 @@ def build_command_line(project):
 @task("analyze")
 def execute_pychecker(project, logger):
     command_line = build_command_line(project)
-    logger.info("Executing pychecker on project sources: %s" % (' '.join(command_line)))
+    logger.info("Executing pychecker on project sources: {0!s}".format((' '.join(command_line))))
 
     _, report_file = execute_tool_on_modules(project, "pychecker", command_line, True)
 

--- a/src/main/python/pybuilder/plugins/python/python_plugin_helper.py
+++ b/src/main/python/pybuilder/plugins/python/python_plugin_helper.py
@@ -99,7 +99,7 @@ def execute_tool_on_modules(project, name, command_and_arguments, extend_pythonp
     modules = discover_modules(source_dir)
     command = as_list(command_and_arguments) + modules
 
-    report_file = project.expand_path("$dir_reports/%s" % name)
+    report_file = project.expand_path("$dir_reports/{0!s}".format(name))
 
     env = os.environ
     if extend_pythonpath:

--- a/src/main/python/pybuilder/plugins/python/sphinx_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/sphinx_plugin.py
@@ -86,7 +86,7 @@ def assert_sphinx_quickstart_is_available(logger):
 
 
 def run_sphinx_build(build_command, task_name, logger, project):
-    logger.info("Running %s" % task_name)
+    logger.info("Running {0!s}".format(task_name))
     log_file = project.expand_path(
         "$dir_target/reports/{0}".format(task_name))
     if project.get_property("verbose"):
@@ -125,18 +125,18 @@ def get_sphinx_quickstart_command(project):
         :param -v: Version of project.
     """
     options = ["-q",
-               "-p '%s'" % project.get_property("sphinx_project_name"),
-               "-a '%s'" % project.get_property("sphinx_doc_author"),
-               "-v %s" % project.get_property("sphinx_project_version"),
-               "%s" % project.expand_path
-               (project.get_property("sphinx_source_dir"))]
-    return "sphinx-quickstart %s" % " ".join(options)
+               "-p '{0!s}'".format(project.get_property("sphinx_project_name")),
+               "-a '{0!s}'".format(project.get_property("sphinx_doc_author")),
+               "-v {0!s}".format(project.get_property("sphinx_project_version")),
+               "{0!s}".format(project.expand_path
+               (project.get_property("sphinx_source_dir")))]
+    return "sphinx-quickstart {0!s}".format(" ".join(options))
 
 
 def get_sphinx_build_command(project):
     """Builds the sphinx-build command using properties.
     """
-    options = ["-b %s" % project.get_property("sphinx_doc_builder"),
+    options = ["-b {0!s}".format(project.get_property("sphinx_doc_builder")),
                project.expand_path(project.get_property("sphinx_config_path")),
                project.expand_path(project.get_property("sphinx_output_dir"))]
-    return "sphinx-build %s" % " ".join(options)
+    return "sphinx-build {0!s}".format(" ".join(options))

--- a/src/main/python/pybuilder/plugins/python/stdeb_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/stdeb_plugin.py
@@ -89,14 +89,14 @@ def get_py2dsc_deb_command(project):
         :param --maintainer: maintainer name and email to use.
         :param -d: directory to put final built.
     """
-    options = ["--maintainer '%s'" % project.get_property("deb_package_maintainer"),
-               "-d '%s'" % project.get_property("path_final_build"),
+    options = ["--maintainer '{0!s}'".format(project.get_property("deb_package_maintainer")),
+               "-d '{0!s}'".format(project.get_property("path_final_build")),
                project.get_property("path_to_source_tarball")]
-    return "py2dsc-deb %s" % " ".join(options)
+    return "py2dsc-deb {0!s}".format(" ".join(options))
 
 
 def run_py2dsc_deb_build(build_command, task_name, logger, project):
-    logger.info("Running %s" % task_name)
+    logger.info("Running {0!s}".format(task_name))
     log_file = project.expand_path(
         "$dir_target/reports/{0}".format(task_name))
     if project.get_property("verbose"):

--- a/src/main/python/pybuilder/plugins/python/test_plugin_helper.py
+++ b/src/main/python/pybuilder/plugins/python/test_plugin_helper.py
@@ -51,12 +51,12 @@ class ReportsProcessor(object):
         self.project.write_report("integrationtest.json", render_report(self.test_report))
         self.logger.info("Executed %d integration tests.", self.tests_executed)
         if self.tests_failed:
-            raise BuildFailedException("%d of %d integration tests failed." % (self.tests_failed, self.tests_executed))
+            raise BuildFailedException("{0:d} of {1:d} integration tests failed.".format(self.tests_failed, self.tests_executed))
 
     def report_to_ci_server(self, project):
         for report in self.reports:
             test_name = report['test']
             test_failed = report['success'] is not True
-            with test_proxy_for(project).and_test_name('Integrationtest.%s' % test_name) as test:
+            with test_proxy_for(project).and_test_name('Integrationtest.{0!s}'.format(test_name)) as test:
                 if test_failed:
                     test.fails(report['exception'])

--- a/src/main/python/pybuilder/plugins/python/unittest_plugin.py
+++ b/src/main/python/pybuilder/plugins/python/unittest_plugin.py
@@ -71,7 +71,7 @@ def run_tests(project, logger, execution_prefix, execution_name):
                                         project, logger, execution_prefix, execution_name))
         if exit_code:
             raise BuildFailedException(
-                "Forked %s process indicated failure with error code %d" % (execution_name, exit_code))
+                "Forked {0!s} process indicated failure with error code {1:d}".format(execution_name, exit_code))
     else:
         do_run_tests(project, logger, execution_prefix, execution_name)
 
@@ -79,24 +79,24 @@ def run_tests(project, logger, execution_prefix, execution_name):
 def do_run_tests(project, logger, execution_prefix, execution_name):
     test_dir = _register_test_and_source_path_and_return_test_dir(project, sys.path, execution_prefix)
 
-    file_suffix = project.get_property("%s_file_suffix" % execution_prefix)
+    file_suffix = project.get_property("{0!s}_file_suffix".format(execution_prefix))
     if file_suffix is not None:
         logger.warn(
-            "%(prefix)s_file_suffix is deprecated, please use %(prefix)s_module_glob" % {"prefix": execution_prefix})
+            "{prefix!s}_file_suffix is deprecated, please use {prefix!s}_module_glob".format(**{"prefix": execution_prefix}))
         module_glob = "*{0}".format(file_suffix)
         if module_glob.endswith(".py"):
             WITHOUT_DOT_PY = slice(0, -3)
             module_glob = module_glob[WITHOUT_DOT_PY]
-        project.set_property("%s_module_glob" % execution_prefix, module_glob)
+        project.set_property("{0!s}_module_glob".format(execution_prefix), module_glob)
     else:
-        module_glob = project.get_property("%s_module_glob" % execution_prefix)
+        module_glob = project.get_property("{0!s}_module_glob".format(execution_prefix))
 
     logger.info("Executing %s from Python modules in %s", execution_name, test_dir)
     logger.debug("Including files matching '%s'", module_glob)
 
     try:
-        test_method_prefix = project.get_property("%s_test_method_prefix" % execution_prefix)
-        runner_generator = project.get_property("%s_runner" % execution_prefix)
+        test_method_prefix = project.get_property("{0!s}_test_method_prefix".format(execution_prefix))
+        runner_generator = project.get_property("{0!s}_runner".format(execution_prefix))
         result, console_out = execute_tests_matching(runner_generator, logger, test_dir, module_glob,
                                                      test_method_prefix)
 
@@ -108,8 +108,7 @@ def do_run_tests(project, logger, execution_prefix, execution_name):
         write_report(execution_prefix, project, logger, result, console_out)
 
         if not result.wasSuccessful():
-            raise BuildFailedException("There were %d error(s) and %d failure(s) in %s"
-                                       % (len(result.errors), len(result.failures), execution_name))
+            raise BuildFailedException("There were {0:d} error(s) and {1:d} failure(s) in {2!s}".format(len(result.errors), len(result.failures), execution_name))
         logger.info("All %s passed.", execution_name)
     except ImportError as e:
         import traceback
@@ -119,7 +118,7 @@ def do_run_tests(project, logger, execution_prefix, execution_name):
         logger.error("Import error in test file {0}, due to statement '{1}' on line {2}".format(
             file_with_error, statement_causing_error, error_line))
         logger.error("Error importing %s: %s", execution_prefix, e)
-        raise BuildFailedException("Unable to execute %s." % execution_name)
+        raise BuildFailedException("Unable to execute {0!s}.".format(execution_name))
 
 
 def execute_tests(runner_generator, logger, test_source, suffix, test_method_prefix=None):
@@ -203,7 +202,7 @@ def _instrument_result(logger, result):
 
 
 def _register_test_and_source_path_and_return_test_dir(project, system_path, execution_prefix):
-    test_dir = project.expand_path("$dir_source_%s_python" % execution_prefix)
+    test_dir = project.expand_path("$dir_source_{0!s}_python".format(execution_prefix))
     system_path.insert(0, test_dir)
     system_path.insert(0, project.expand_path("$dir_source_main_python"))
 
@@ -211,7 +210,7 @@ def _register_test_and_source_path_and_return_test_dir(project, system_path, exe
 
 
 def write_report(name, project, logger, result, console_out):
-    project.write_report("%s" % name, console_out)
+    project.write_report("{0!s}".format(name), console_out)
 
     report = {"tests-run": result.testsRun,
               "errors": [],
@@ -233,7 +232,7 @@ def write_report(name, project, logger, result, console_out):
         if project.get_property("verbose"):
             print_text_line(failure[1])
 
-    project.write_report("%s.json" % name, render_report(report))
+    project.write_report("{0!s}.json".format(name), render_report(report))
 
     report_to_ci_server(project, result)
 

--- a/src/main/python/pybuilder/plugins/ronn_manpage_plugin.py
+++ b/src/main/python/pybuilder/plugins/ronn_manpage_plugin.py
@@ -75,8 +75,8 @@ def generate_manpages(project, logger):
 
 
 def build_generate_manpages_command(project):
-    ronn_pipe_command = 'ronn -r --pipe %s' % project.get_property('manpage_source')
-    compressed_manpage_file = '%s.%d.gz' % (project.name, project.get_property('manpage_section'))
-    compress_command = 'gzip -9 > %s' % os.path.join(project.get_property('dir_manpages'), compressed_manpage_file)
-    generate_manpages_command = '%s | %s' % (ronn_pipe_command, compress_command)
+    ronn_pipe_command = 'ronn -r --pipe {0!s}'.format(project.get_property('manpage_source'))
+    compressed_manpage_file = '{0!s}.{1:d}.gz'.format(project.name, project.get_property('manpage_section'))
+    compress_command = 'gzip -9 > {0!s}'.format(os.path.join(project.get_property('dir_manpages'), compressed_manpage_file))
+    generate_manpages_command = '{0!s} | {1!s}'.format(ronn_pipe_command, compress_command)
     return generate_manpages_command

--- a/src/main/python/pybuilder/plugins/source_distribution_plugin.py
+++ b/src/main/python/pybuilder/plugins/source_distribution_plugin.py
@@ -26,7 +26,7 @@ use_plugin("core")
 
 @init
 def init_source_distribution(project):
-    source_distribution_directory = "$dir_target/dist/%s-%s-src" % (project.name, project.version)
+    source_distribution_directory = "$dir_target/dist/{0!s}-{1!s}-src".format(project.name, project.version)
     project.set_property_if_unset("dir_source_dist", source_distribution_directory)
     project.set_property_if_unset("source_dist_ignore_patterns", ["*.pyc", ".hg*", ".svn", ".CVS"])
 

--- a/src/main/python/pybuilder/reactor.py
+++ b/src/main/python/pybuilder/reactor.py
@@ -191,11 +191,11 @@ class Reactor(object):
     def log_project_properties(self):
         formatted = ""
         for key in sorted(self.project.properties):
-            formatted += "\n%40s : %s" % (key, self.project.get_property(key))
+            formatted += "\n{0:40!s} : {1!s}".format(key, self.project.get_property(key))
         self.logger.debug("Project properties: %s", formatted)
 
     def import_plugin(self, plugin, version=None, plugin_module_name=None):
-        self.logger.debug("Loading plugin '%s'%s", plugin, " version %s" % version if version else "")
+        self.logger.debug("Loading plugin '%s'%s", plugin, " version {0!s}".format(version) if version else "")
         plugin_module = self.plugin_loader.load_plugin(self.project, plugin, version, plugin_module_name)
         self.collect_tasks_and_actions_and_initializers(plugin_module)
 
@@ -306,7 +306,7 @@ class Reactor(object):
             return imp.load_source("build", project_descriptor)
         except ImportError as e:
             raise PyBuilderException(
-                "Error importing project descriptor %s: %s" % (project_descriptor, e))
+                "Error importing project descriptor {0!s}: {1!s}".format(project_descriptor, e))
 
     @staticmethod
     def verify_project_directory(project_directory, project_descriptor):

--- a/src/main/python/pybuilder/scaffolding.py
+++ b/src/main/python/pybuilder/scaffolding.py
@@ -70,7 +70,7 @@ def suggest_plugins(plugins):
 
 
 def suggest(plugin):
-    choice = prompt_user('Use plugin %s (Y/n)?' % plugin, 'y')
+    choice = prompt_user('Use plugin {0!s} (Y/n)?'.format(plugin), 'y')
     plugin_enabled = not choice or choice.lower() == 'y'
     return plugin if plugin_enabled else None
 
@@ -222,7 +222,7 @@ def set_properties(project):
         return self.DESCRIPTOR_TEMPLATE.substitute(self.__dict__)
 
     def build_imports(self):
-        self.activated_plugins = '\n'.join(['use_plugin("%s")' % plugin for plugin in self.plugins])
+        self.activated_plugins = '\n'.join(['use_plugin("{0!s}")'.format(plugin) for plugin in self.plugins])
 
     def build_initializer(self):
         self.core_imports.append('init')

--- a/src/main/python/pybuilder/terminal.py
+++ b/src/main/python/pybuilder/terminal.py
@@ -72,7 +72,7 @@ def styled_text(text, *style_attributes):
         - the text itself
         - a reset of all style attributes
     """
-    return "%s%s%s" % (
+    return "{0!s}{1!s}{2!s}".format(
         _ESCAPE_SEQUENCE_PATTERN % (_ESCAPE_SEQUENCE_SEPARATOR.join(style_attributes)),
         text,
         _ESCAPE_SEQUENCE_PATTERN % "0;0")

--- a/src/main/python/pybuilder/utils.py
+++ b/src/main/python/pybuilder/utils.py
@@ -323,9 +323,9 @@ def fork_process(logger, group=None, target=None, name=None, args=(), kwargs={})
             raise_exception(result[1], result[2])
         return p.exitcode, result[0]
     else:
-        msg = "Fatal error occurred in the forked process %s: %s" % (p, result.args[0])
+        msg = "Fatal error occurred in the forked process {0!s}: {1!s}".format(p, result.args[0])
         if result.args[2]:
-            chained_message = "This error masked the send error '%s':\n%s" % (
+            chained_message = "This error masked the send error '{0!s}':\n{1!s}".format(
                 result.args[2], "".join(traceback.format_tb(result.args[3])))
             msg += "\n" + chained_message
         ex = Exception(msg)
@@ -365,7 +365,7 @@ if sys.version_info[0] == 2 and sys.version_info[1] == 6:  # if Python is 2.6
 
             '''
             if len(args) > 1:
-                raise TypeError('expected at most 1 arguments, got %d' % len(args))
+                raise TypeError('expected at most 1 arguments, got {0:d}'.format(len(args)))
             try:
                 self.__root
             except AttributeError:
@@ -535,8 +535,8 @@ if sys.version_info[0] == 2 and sys.version_info[1] == 6:  # if Python is 2.6
             _repr_running[call_key] = 1
             try:
                 if not self:
-                    return '%s()' % (self.__class__.__name__,)
-                return '%s(%r)' % (self.__class__.__name__, self.items())
+                    return '{0!s}()'.format(self.__class__.__name__)
+                return '{0!s}({1!r})'.format(self.__class__.__name__, self.items())
             finally:
                 del _repr_running[call_key]
 

--- a/src/unittest/python/core_tests.py
+++ b/src/unittest/python/core_tests.py
@@ -406,12 +406,12 @@ class LoggerTest(unittest.TestCase):
         def assert_not_logged(self, level, message, *arguments):
             if (level, message, arguments) in self._logged:
                 raise AssertionError(
-                    "Logged %s %s %s" % (level, message, arguments))
+                    "Logged {0!s} {1!s} {2!s}".format(level, message, arguments))
 
         def assert_logged(self, level, message, *arguments):
             if (level, message, arguments) not in self._logged:
                 raise AssertionError(
-                    "Not logged %s %s %s" % (level, message, arguments))
+                    "Not logged {0!s} {1!s} {2!s}".format(level, message, arguments))
 
     def test_should_log_debug_message_without_arguments(self):
         logger = LoggerTest.LoggerMock(Logger.DEBUG)

--- a/src/unittest/python/reactor_tests.py
+++ b/src/unittest/python/reactor_tests.py
@@ -51,7 +51,7 @@ class TaskNameMatcher(Matcher):
         return arg.name == self.task_name
 
     def repr(self):
-        return "Task with name %s" % self.task_name
+        return "Task with name {0!s}".format(self.task_name)
 
 
 class ReactorTest(unittest.TestCase):

--- a/src/unittest/python/utils_tests.py
+++ b/src/unittest/python/utils_tests.py
@@ -85,7 +85,7 @@ class FormatTimestampTest(unittest.TestCase):
     def assert_matches(self, regex, actual, message=None):
         if not re.match(regex, actual):
             if not message:
-                message = "'%s' does not match '%s'" % (actual, regex)
+                message = "'{0!s}' does not match '{1!s}'".format(actual, regex)
 
             self.fail(message)
 
@@ -363,7 +363,7 @@ class ForkTest(unittest.TestCase):
 
     def testForkParamPassing(self):
         def test_func(foo, bar):
-            return "%s%s" % (foo, bar)
+            return "{0!s}{1!s}".format(foo, bar)
 
         val = fork_process(mock(), target=test_func, kwargs={"foo": "foo", "bar": 10})
         self.assertEquals(len(val), 2)
@@ -381,7 +381,7 @@ class ForkTest(unittest.TestCase):
 
         try:
             val = fork_process(mock(), target=test_func)
-            self.fail("should not have reached here, returned %s" % val)
+            self.fail("should not have reached here, returned {0!s}".format(val))
         except:
             ex_type, ex, tb = sys.exc_info()
             self.assertEquals(ex_type, PyBuilderException)
@@ -416,7 +416,7 @@ class ForkTest(unittest.TestCase):
 
         try:
             val = fork_process(mock(), target=test_func)
-            self.fail("should not have reached here, returned %s" % val)
+            self.fail("should not have reached here, returned {0!s}".format(val))
         except:
             ex_type, ex, tb = sys.exc_info()
             self.assertEquals(ex_type, Exception)
@@ -439,7 +439,7 @@ class ForkTest(unittest.TestCase):
 
         try:
             val = fork_process(mock(), target=test_func)
-            self.fail("should not have reached here, returned %s" % val)
+            self.fail("should not have reached here, returned {0!s}".format(val))
         except:
             ex_type, ex, tb = sys.exc_info()
             self.assertEquals(ex_type, Exception)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:pybuilder?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:pybuilder?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
